### PR TITLE
Ensembl GTF compatibility and NMD stall prevention

### DIFF
--- a/src/leafcutter2/classifier.py
+++ b/src/leafcutter2/classifier.py
@@ -434,8 +434,8 @@ def check_utrs(junc,strand,start_codons,stop_codons):
         return True
     return False
 
-def solve_NMD(chrom, strand, junc, start_codons, stop_codons,gene_name, fa, 
-              verbose = False, exonLcutoff = 2000):
+def solve_NMD(chrom, strand, junc, start_codons, stop_codons, gene_name, fa,
+              verbose=False, exonLcutoff=2000, max_paths=100000, max_exon_search=100000):
     '''
     Compute whether there is a possible combination that uses the junction without
     inducing a PTC. We start with all annotated stop codon and go backwards.
@@ -465,12 +465,23 @@ def solve_NMD(chrom, strand, junc, start_codons, stop_codons,gene_name, fa,
     dic_terminus = {}
 
     depth = 0
-    """Quinn Comment: while our seed length is greater than 0 - which means we have charted all possible paths through 
+    paths_explored = 0
+    truncated = False
+
+    """Quinn Comment: while our seed length is greater than 0 - which means we have charted all possible paths through
     all junctions ending in a stop codon (or there is an exon longer than 1000 bp and we have no complete paths)"""
     while len(seed) > 0:
         new_seed = []
         final_check = []
         depth += 1
+
+        # Check path limit to prevent memory blowup
+        paths_explored += len(seed)
+        if paths_explored > max_paths:
+            logger.warning(f"{gene_name} exceeded {max_paths} paths at depth {depth}, truncating search")
+            truncated = True
+            break
+
         if verbose:
             logger.debug(f"Depth {depth}, Seed L = {len(seed)}")
                     
@@ -548,7 +559,7 @@ def solve_NMD(chrom, strand, junc, start_codons, stop_codons,gene_name, fa,
             next_exon_max = 0
 
             ptc_ahead = False
-            while ptc_ahead == False:
+            while ptc_ahead == False and next_exon_max < max_exon_search:
                 next_exon_max += 500
                 endpos = (len(leftover)+next_exon_max+1)%3
                 if strand == '+':
@@ -631,12 +642,26 @@ def solve_NMD(chrom, strand, junc, start_codons, stop_codons,gene_name, fa,
                         junc_pass[j_coord] = 0
                     junc_pass[j_coord] += 1
 
+        # Limit new_seed size to prevent memory blowup in single iteration
+        if len(new_seed) > max_paths:
+            logger.warning(f"{gene_name} new_seed size ({len(new_seed)}) exceeds limit, keeping first {max_paths} paths")
+            new_seed = new_seed[:max_paths]
+            truncated = True
+
         seed = new_seed
     
     
     """Quinn Comment: OUT OF WHILE LOOP through all possible paths/seeds; 
     check all terminus' to see if they are part of a full path that has been classified as passing"""
+    terminus_iterations = 0
+    max_terminus_iterations = 50000
+
     while True:
+        terminus_iterations += 1
+        if terminus_iterations > max_terminus_iterations:
+            logger.warning(f"{gene_name} terminus checking exceeded {max_terminus_iterations} iterations, stopping")
+            break
+
         new_paths = []
         for terminus in dic_terminus:
             terminus_pass = False
@@ -704,10 +729,19 @@ def parse_gtf(gtf: str,
         }
 
         for standard_key, custom_attr in attribute_mapping.items():
-            try: 
+            try:
                 dic[standard_key] = info_fields[custom_attr]
             except KeyError:
                 dic[standard_key] = None
+
+        # Fallback: use gene_id if gene_name is missing (common in Ensembl GTFs)
+        if dic.get('gene_name') is None and 'gene_id' in info_fields:
+            dic['gene_name'] = info_fields['gene_id']
+
+        # Fallback: use transcript_id if transcript_name is missing
+        if dic.get('transcript_name') is None and 'transcript_id' in info_fields:
+            dic['transcript_name'] = info_fields['transcript_id']
+
         yield dic
          
 
@@ -862,12 +896,13 @@ def overlaps(A: tuple, B: tuple):
 
 
 def ClassifySpliceJunction(
-    perind_file: str, 
-    gtf_annot: str, 
+    perind_file: str,
+    gtf_annot: str,
     fa,
     rundir: str = ".",
     outprefix: str = "Leaf2",
     max_juncs: int = 10000,
+    max_paths: int = 100000,
     keepannot: bool = False,
     gene_type: str = "gene_type",
     transcript_type: str = "transcript_type",
@@ -1026,9 +1061,10 @@ def ClassifySpliceJunction(
         
         if len(junctions) <= max_juncs:
             try:
-                junc_pass, junc_fail = solve_NMD(chrom,strand,junctions, 
-                                                start_codons, stop_codons, 
-                                                gene_name, fa)
+                junc_pass, junc_fail = solve_NMD(chrom, strand, junctions,
+                                                start_codons, stop_codons,
+                                                gene_name, fa,
+                                                max_paths=max_paths)
                 junc_fail = set(junc_fail.keys())
                 junc_pass = set(junc_pass.keys())
             except:

--- a/src/leafcutter2/classifier.py
+++ b/src/leafcutter2/classifier.py
@@ -734,14 +734,6 @@ def parse_gtf(gtf: str,
             except KeyError:
                 dic[standard_key] = None
 
-        # Fallback: use gene_id if gene_name is missing (common in Ensembl GTFs)
-        if dic.get('gene_name') is None and 'gene_id' in info_fields:
-            dic['gene_name'] = info_fields['gene_id']
-
-        # Fallback: use transcript_id if transcript_name is missing
-        if dic.get('transcript_name') is None and 'transcript_id' in info_fields:
-            dic['transcript_name'] = info_fields['transcript_id']
-
         yield dic
          
 

--- a/src/leafcutter2/pipeline.py
+++ b/src/leafcutter2/pipeline.py
@@ -1304,19 +1304,81 @@ def validate_gtf_requirements(gtf_file, options, CheckRequirementsEveryNLines=No
                 logger.error(f"  Suggestion: Your GTF may use non-standard attribute names\n")
                 raise SystemExit(1)
     
+    # For non-required attributes (anything other than gene_id/transcript_id), verify that
+    # the chosen attribute is actually populated in every record across the full GTF.
+    # gene_id and transcript_id are required by the GTF spec and can be trusted without a
+    # full scan. If any records are missing a non-required attribute, fall back to the safe
+    # required alternative and warn the user.
+    safe_defaults = {'gene_name': 'gene_id', 'transcript_name': 'transcript_id'}
+    attrs_to_check = {
+        opt: getattr(options, opt)
+        for opt in ('gene_name', 'transcript_name')
+        if getattr(options, opt) != safe_defaults[opt]
+    }
+
+    if attrs_to_check:
+        logger.info(
+            f"Performing full GTF scan to verify completeness of non-required attributes: "
+            f"{list(attrs_to_check.values())}\n"
+        )
+        null_counts = {opt: 0 for opt in attrs_to_check}
+        total_data_lines = 0
+        try:
+            opener = gzip.open if gtf_file.endswith('.gz') else open
+            with opener(gtf_file, 'rt') as fh:
+                for line in fh:
+                    if line.startswith('#') or not line.strip():
+                        continue
+                    fields = line.strip().split('\t')
+                    if len(fields) < 9:
+                        continue
+                    total_data_lines += 1
+                    attrs_str = fields[8]
+                    parsed = {}
+                    for attr_pair in attrs_str.split(';'):
+                        attr_pair = attr_pair.strip()
+                        if not attr_pair:
+                            continue
+                        if '"' in attr_pair:
+                            parts = attr_pair.split('"')
+                            if len(parts) >= 2:
+                                parsed[parts[0].strip()] = parts[1]
+                        else:
+                            parts = attr_pair.split(None, 1)
+                            if len(parts) == 2:
+                                parsed[parts[0]] = parts[1]
+                    for opt, attr in attrs_to_check.items():
+                        if not parsed.get(attr, '').strip():
+                            null_counts[opt] += 1
+        except Exception as e:
+            logger.warning(f"Could not verify attribute completeness: {e}\n")
+
+        for opt, attr in list(attrs_to_check.items()):
+            if null_counts[opt] > 0:
+                fallback = safe_defaults[opt]
+                logger.warning(
+                    f"Attribute '{attr}' missing or empty in {null_counts[opt]}/{total_data_lines} "
+                    f"GTF records; falling back to required attribute '{fallback}'\n"
+                )
+                setattr(options, opt, fallback)
+                if opt in auto_detected:
+                    auto_detected[opt] = fallback
+                elif opt in user_specified:
+                    user_specified[opt] = fallback
+
     # Print summary of what was used
     if user_specified:
         logger.info("Using user-specified GTF attributes:\n")
         for option_name, value in user_specified.items():
             logger.info(f"  {option_name}: {value}\n")
-            
+
     if auto_detected:
         logger.info("Auto-detected GTF attributes:\n")
         for option_name, value in auto_detected.items():
             logger.info(f"  {option_name}: {value} (auto-detected)\n")
-    
+
     logger.info("GTF validation and attribute detection complete.\n")
-    
+
     return options
 
 def has_cds_feature(gtf_file: str) -> bool:


### PR DESCRIPTION
## Summary

This PR incorporates work from @DylanMaxStermer's PR #8, with a modified approach to the GTF attribute compatibility problem.

**From Dylan's PR (preserved with original authorship):**
- `solve_NMD`: add `max_paths` and `max_exon_search` limits to prevent memory blowup and infinite loops in genes with complex splicing graphs
- `solve_NMD`: cap `new_seed` size mid-loop and add iteration cap on the terminus-checking `while True` loop
- `ClassifySpliceJunction`: expose `max_paths` as a tunable parameter

**Modified approach for Ensembl GTF `gene_name` compatibility:**

Dylan's PR added per-record fallbacks inside `parse_gtf` (falling back to `gene_id` when `gene_name` is absent). We already had `validate_gtf_requirements` / `validate_or_reformat_gtf` which auto-detects the right attribute name before any parsing occurs — so the per-record fallback was redundant and at the wrong layer.

However, there was a genuine gap: `validate_gtf_requirements` detected attribute *keys* but not whether values were consistently populated. `gene_id` and `transcript_id` are required by the GTF spec and can be trusted, but `gene_name` may be absent in some records of Ensembl GTFs even when the key exists elsewhere.

The fix: after attribute detection, if the chosen `gene_name` or `transcript_name` attribute is anything other than `gene_id`/`transcript_id`, `validate_gtf_requirements` now performs a full GTF scan to verify completeness. If any records are missing a value, it falls back to the spec-required field with a warning.

## Test plan
- [ ] All 7 existing integration tests pass
- [ ] Tested with a standard GENCODE GTF (gene_name present throughout — no fallback triggered)
- [ ] Manually verify with an Ensembl GTF that `gene_id` is selected and logged correctly when `gene_name` values are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)